### PR TITLE
Configurable ports, Browserify dep, bin-ify server

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "BSD-3-Clause",
     "url": "http://polymer.github.io/LICENSE.txt"
   },
+  "bin": {
+    "polymer-designer": "./server.js"
+  },
   "main": "main.js",
   "scripts": {
     "build": "./build.sh"
@@ -18,12 +21,14 @@
     "dom5": "^1.0.1",
     "express": "^4.8.5",
     "hydrolysis": "^1.0.0",
+    "minimist": "^1.1.1",
     "parse5": "^1.4.0",
     "polyserve": "^0.4.0",
     "resolve": "^1.0.0",
     "send": "^0.10.1"
   },
   "devDependencies": {
+    "browserify": "^10.2.3",
     "chai": "^1.9.2",
     "mocha": "^2.0.1"
   }

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
@@ -7,5 +8,8 @@
  * Code distributed by Google as part of the polymer project is also
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
-
-require('./src/server/server').startServer();
+var argv = require('minimist')(process.argv.slice(2));
+require('./src/server/server').startServer(
+  argv.port || argv.p,
+  argv['files-port'] || argv.f
+);

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -13,12 +13,14 @@ var path = require('path');
 var send = require('send');
 var files = require('./files');
 
-function startServer() {
-  console.log('Starting Polymer Designer Server on port 8080');
+function startServer(serverPort, filesPort) {
   var app = express();
-  // TODO: allow port to be set with flag, fallback to other ports
-  var port = 8080;
-  var filesPort = 8081;
+
+  serverPort = parseInt(serverPort || 8080, 10);
+  filesPort = parseInt(filesPort || (serverPort + 1), 10);
+
+  console.log('Starting Polymer Designer Server on port ' + serverPort);
+  console.log('Serving files on port ' + filesPort);
 
   app.get('/', function(req, res) {
     send(req, path.join(__dirname, 'index.html')).pipe(res);
@@ -28,7 +30,7 @@ function startServer() {
 
   app.use('/components', require('./components'));
 
-  var server = app.listen(port);
+  var server = app.listen(serverPort);
   files.app.listen(filesPort);
 }
 


### PR DESCRIPTION
 - Ports can be configured with `-p` or `--port` for the web server and
   `-f` or `--files-port` for the file server.
 - Browserify package has been added to `devDependencies`.
 - Server.js has been mapped to the `polymer-designer` virtual binary.