### PR TITLE
Bundle current selection and document related data to make data-flow easier to manage.

### DIFF
--- a/elements/designer-app/designer-app.html
+++ b/elements/designer-app/designer-app.html
@@ -223,12 +223,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <div>
             <h3>Document</h3>
             <designer-document-outline
-                root-node=[[domDocumentElement]]
-                current-node="[[currentNode]]">
+                root-node=[[documentInfo.domDocumentElement]]>
             </designer-document-outline>
             <h3>Elements</h3>
             <ul>
-              <template is="dom-repeat" items="[[elements]]">
+              <template is="dom-repeat" items="[[documentInfo.elements]]">
                 <li>[[item.is]]</li>
               </template>
             </ul>
@@ -248,10 +247,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </paper-tabs>
         </template>
       </paper-toolbar>
-      <!-- <template is="dom-if" if="{{domDocument}}">
-        <designer-breadcrumb node="{{currentNode}}"></designer-breadcrumb>
-      </template> -->
-      <designer-breadcrumb node="[[currentNode]]"></designer-breadcrumb>
+      <designer-breadcrumb node="[[selection.node]]"></designer-breadcrumb>
       <iron-pages id="editor" selected="[[_selectedEditor]]">
         <div id="storyboard">
           Storyboard
@@ -260,45 +256,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <div id="doc-view">
             <designer-document
                 id="document"
-                source="[[documentSource]]"
-                url="[[documentUrl]]"
                 client-connection="[[clientConnection]]"
-                analyzer="{{analyzer}}"
                 client="{{client}}"
-                dom-document="{{domDocument}}"
-                dom-document-element="{{domDocumentElement}}"
-                ast-document="{{astDocument}}"
-                ast-document-element="{{astDocumentElement}}"
-                text-content="{{textContent}}"
-                elements="{{elements}}"
-                filename="{{filename}}"
-                current-node="{{currentNode}}"
-                current-path="{{currentPath}}"
-                current-source-id="{{currentSourceId}}"
-                current-element-info="{{currentElementInfo}}"
-                on-designer-document-update="_onDesignerDocumentUpdate">
+                document-info="{{documentInfo}}"
+                selection="{{selection}}">
             </designer-document>
             <designer-stage
                 id="stage"
-                dom-document="[[domDocument]]"
-                analyzer="[[analyzer]]"
+                document-info="[[documentInfo]]"
                 client="[[client]]"
-                current-source-id="[[currentSourceId]]"
-                current-element-info="[[currentElementInfo]]"
+                selection="[[selection]]"
                 on-designer-command="_onDesignerCommand">
               <designer-frame
                   id="frame"
                   client-connection="{{clientConnection}}"
-                  document="[[domDocument]]">
+                  document-info="[[documentInfo]]">
               </designer-frame>
             </designer-stage>
             <pre id="html">[[textContent]]</pre>
           </div> <!-- doc-view -->
-          <template is="dom-if" if="[[domDocument]]">
+          <template is="dom-if" if="[[documentInfo]]">
             <designer-inspector
-                source-document="[[domDocument]]"
-                element-info="[[currentElementInfo]]"
-                current-node="[[currentNode]]">
+                document-info="[[documentInfo]]"
+                selection="[[selection]]">
             </designer-inspector>
           </template>
         </div> <!-- editor -->
@@ -312,21 +292,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
 
   define([
-    'polymer-designer/path',
     'polymer-designer/dom-utils',
     'polymer-designer/files'],
-      function(pathLib, domUtils, files) {
+      function(domUtils, files) {
     'use strict';
 
     Polymer({
       is: 'designer-app',
 
       properties: {
-
-        analyzer: {
-          type: Object,
-          notify: true,
-        },
 
         client: {
           type: Object,
@@ -338,58 +312,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           notify: true,
         },
 
-        currentElementInfo: {
+        selection: {
           type: Object,
-          notify: true,
         },
 
-        currentNode: {
+        documentInfo: {
           type: Object,
-          notify: true,
-        },
-
-        currentSourceId: {
-          type: String,
-          notify: true,
-        },
-
-        domDocument: {
-          type: Object,
-          notify: true,
-        },
-
-        domDocumentElement: {
-          type: Object,
-          notify: true,
-        },
-
-        astDocument: {
-          type: Object,
-          notify: true,
-        },
-
-        astDocumentElement: {
-          type: Object,
-          notify: true,
-        },
-
-        elements: {
-          type: Array,
-        },
-
-        textContent: {
-          type: String,
-          notify: true,
-        },
-
-        documentSource: {
-          type: String,
-          notify: true,
-        },
-
-        documentUrl: {
-          type: String,
-          notify: true,
         },
 
         _selectedNavTab: {
@@ -430,11 +358,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _onDesignerSelectElement(event, detail) {
-        // This triggers a sync between currentSourceId, currentPath and
-        // currentNode in designer-document
-        // TODO(justinfagnani): consider chaning to calling a method on
-        // designer-document
-        this.currentSourceId = detail.sourceId;
+        this.$.document.setSourceId(detail.sourceId);
       },
 
       _onDesignerCommand(event, command) {
@@ -443,15 +367,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.$.document.executeCommand(command);
       },
 
-      _onDesignerDocumentUpdate(event, response) {
-        // Event fired from designer-stage containing an edit response,
-        // forward to the designer-stage.
-        this.$.stage.applyDocumentUpdate(response);
-      },
-
       _onFileDataLoad(e) {
-        this.documentSource = e.detail.file;
-        this.documentUrl = e.detail.href;
+        this.$.document.setDocument(e.detail.file, e.detail.href);
       },
 
       _installPackageClick(e) {

--- a/elements/designer-breadcrumb/designer-breadcrumb.html
+++ b/elements/designer-breadcrumb/designer-breadcrumb.html
@@ -7,7 +7,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../../src/commands/commands.html">
+<link rel="import" href="../../src/dom-utils/dom-utils.html">
 <link rel="import" href="../../../polymer/polymer.html">
 <link rel="import" href="../../../paper-tabs/paper-tabs.html">
 <link rel="import" href="../../../paper-tabs/paper-tab.html">
@@ -31,7 +31,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </style>
 
   <template>
-    <paper-tabs selected="{{selectedIndex}}" noink noslide>
+    <paper-tabs selected="{{_selectedIndex}}" noink noslide>
       <template is="dom-repeat" items="[[_tabNames]]">
         <paper-tab>[[item]]</paper-tab>
       </template>
@@ -62,9 +62,8 @@ define(['polymer-designer/dom-utils'], function(domUtils) {
       /**
        * @type {number}
        */
-      selectedIndex: {
+      _selectedIndex: {
         type: Number,
-        notify: true,
         value: 0,
         observer: '_selectedIndexChanged',
       },
@@ -89,7 +88,7 @@ define(['polymer-designer/dom-utils'], function(domUtils) {
     _nodeChanged() {
       let node = this.node;
 
-      if (node === null) {
+      if (node == null) {
         this._nodePath = [];
         this._tabNames = [];
         return;
@@ -99,7 +98,7 @@ define(['polymer-designer/dom-utils'], function(domUtils) {
       // recompute the breadcrumb path, just select the new node.
       let index = this._nodePath.indexOf(node);
       if (index !== -1) {
-        this.selectedIndex = index;
+        this._setIndex(index);
         return;
       }
 
@@ -112,13 +111,22 @@ define(['polymer-designer/dom-utils'], function(domUtils) {
         }
         return name;
       });
-      this.selectedIndex = this._nodePath.length - 1;
+      this._setIndex(this._nodePath.length - 1);
+    },
+
+    // prevents firing designer-select-element when index changes from the
+    // node being set externally
+    _setIndex(index) {
+      this._settingIndex = true;
+      this._selectedIndex = index;
+      this._settingIndex = false;
     },
 
     _selectedIndexChanged() {
-      if (this._nodePath !== null &&
-          this.selectedIndex < this._nodePath.length) {
-        let newNode = this._nodePath[this.selectedIndex];
+      if (!this._settingIndex &&
+          this._nodePath != null &&
+          this._selectedIndex < this._nodePath.length) {
+        let newNode = this._nodePath[this._selectedIndex];
         this.fire('designer-select-element', {
           sourceId: domUtils.getSourceId(newNode),
         }, { bubbles: true, });

--- a/elements/designer-document/designer-document.html
+++ b/elements/designer-document/designer-document.html
@@ -59,18 +59,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     'use strict';
 
-    // TODO(justinfagnani): move to common location
-    const nodeIdProperty = '__designer_node_id__';
+    const sourceIdAttribute = domUtils.sourceIdAttribute;
 
     Polymer({
       is: 'designer-document',
 
       properties: {
-
-        analyzer: {
-          type: Object,
-          notify: true,
-        },
 
         client: {
           type: Object,
@@ -83,66 +77,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           observer: '_clientConnectionChanged',
         },
 
-        currentNode: {
-          type: Object,
-          notify: true,
-          observer: '_currentNodeChanged',
-        },
-
-        currentPath: {
-          type: String,
-          notify: true,
-          observer: '_currentPathChanged',
-        },
-
-        currentSourceId: {
-          type: String,
-          notify: true,
-          observer: '_currentSourceIdChanged',
-        },
-
-        currentElementInfo: {
+        selection: {
           type: Object,
           notify: true,
         },
 
-        domDocument: {
+        documentInfo: {
           type: Object,
           notify: true,
         },
-
-        domDocumentElement: {
-          type: Object,
-          notify: true,
-        },
-
-        astDocument: {
-          type: Object,
-          notify: true,
-        },
-
-        astDocumentElement: {
-          type: Object,
-          notify: true,
-        },
-
-        elements: {
-          type: Array,
-          notify: true,
-        },
-
-        textContent: {
-          type: String,
-          notify: true,
-        },
-
-        filename: {
-          type: String,
-          notify: true,
-        },
-
-        source: String,
-        url: String,
 
         _domNodes: {
           type: Map,
@@ -153,10 +96,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       },
 
-      observers: [
-        '_setDocument(source,url)',
-      ],
-
       /**
        * Sets the current document and injects the message handler script.
        *
@@ -164,14 +103,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {string} url The document location.
        * @returns {Promise<Document>} The modified document.
        */
-      _setDocument(content, url) {
-        this.analyzer = createAnalyzer(url);
-
-        let splitUrl = url.split('/');
-        this.filename = splitUrl[splitUrl.length - 1];
+      setDocument(content, url) {
+        let analyzer = createAnalyzer(url);
 
         return Promise.all([
-          this.analyzer.load(url),
+          analyzer.load(url),
           this._frameScriptAsset.load(),
         ]).then(function(results) {
           let analyzedDocument = results[0];
@@ -184,60 +120,87 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             let parsedDocument = results[0];
             let metadata = results[1];
 
-            this.domDocument = createDocument(content, frameScript, url);
-            this.domDocumentElement = domUtils.getDocumentElement(this.domDocument);
+            let domDocument = createDocument(content, frameScript, url);
+            let domDocumentElement = domUtils.getDocumentElement(domDocument);
 
-            this.astDocument = parsedDocument.ast;
-            this.astDocumentElement = domUtils.getDocumentElement(this.astDocument);
+            let astDocument = parsedDocument.ast;
+            let astDocumentElement = domUtils.getDocumentElement(astDocument);
+
+            // assign sequential IDs to all elements in the document
             let nextId = 1;
-            dom5.query(this.astDocument, function(node) {
-              dom5.setAttribute(node, nodeIdProperty, `${nextId++}`);
+            dom5.query(astDocument, function(node) {
+              dom5.setAttribute(node, sourceIdAttribute, `${nextId++}`);
             });
 
-            this.elements = metadata.elements;
-            this.textContent = dom5.serialize(this.astDocument);
+            let elements = metadata.elements;
+            let textContent = dom5.serialize(astDocument);
 
-            this._domCommandApplier = new DomCommandApplier(this.domDocument);
+            let splitUrl = url.split('/');
+            let filename = splitUrl[splitUrl.length - 1];
+
+            this._domCommandApplier = new DomCommandApplier(domDocument);
             this._parsedCommandApplier =
-                new ParsedHtmlCommandApplier(this.astDocument);
+                new ParsedHtmlCommandApplier(astDocument);
+
+            // TODO(justinfagnani): cleanup
+            //   - define a class and jscompiler type?
+            //   - remove document element proeprties
+            //   - add method to query element by sourceId
+            //   - only include one public text document
+            //   - don't include both elements and analyzer?
+            this.documentInfo = {
+              domDocument: domDocument,
+              domDocumentElement: domDocumentElement,
+              astDocument: astDocument,
+              astDocumentElement: astDocumentElement,
+              elements: elements,
+              textContent: textContent,
+              analyzer: analyzer,
+              source: content,
+              url: url,
+              filename: filename,
+            };
           }.bind(this));
 
         }.bind(this));
       },
 
-      _currentNodeChanged() {
-        let path = this.currentPath = (this.currentNode)
-            ? pathLib.getNodePath(this.currentNode, this.domDocument)
-            : null;
-        this.currentSourceId = (this.currentNode && this.currentNode.nodeType === Node.ELEMENT_NODE)
-            ? this.currentNode.getAttribute(nodeIdProperty)
-            : null;
-        if (this.client != null) {
-          this.client.selectElementAtPath(path).then(function(response) {
-            this.fire('designer-document-update', response);
-          }.bind(this));
+      /**
+       * Sets the current source ID which we use to set the current selection.
+       *
+       * @param {string} sourceId The source ID of the element to select.
+       * @returns {Promise<>} A promise that completes with the operation.
+       */
+      setSourceId(sourceId) {
+        if (sourceId == null || this.client == null) {
+          this.selection = null;
+          return Promise.resolve();
+        } else {
+          return this.client.selectElementForSourceId(sourceId)
+            .then(function(response) {
+              let tagName = response.elementInfo.tagName;
+              // TODO(justinfagnani): create class for selectino object
+              this.selection = {
+                elementInfo: response.elementInfo,
+                bounds: response.bounds,
+                // TODO(justinfagnani): add method for retrieving elements by id
+                node: this.documentInfo.domDocument.querySelector(
+                    `[${sourceIdAttribute}="${sourceId}"]`),
+                analysisInfo: this._getAnalysisInfo(tagName),
+              };
+            }.bind(this));
         }
       },
 
-      _currentPathChanged() {
-        this.currentNode = (this.currentPath)
-            ? pathLib.getNodeFromPath(this.currentPath, this.domDocument)
-            : null;
-      },
-
-      _currentSourceIdChanged() {
-        this.currentNode = (this.currentSourceId)
-            ? this.domDocument.querySelector(`[__designer_node_id__="${this.currentSourceId}"]`)
-            : null;
+      _getAnalysisInfo(tagName) {
+        return this.documentInfo.analyzer.elementsByTagName[tagName];
       },
 
       _clientConnectionChanged() {
         if (this.clientConnection) {
           this.client = new DocumentClient(this.clientConnection);
           this.client.getDocument().then(function(response) {
-            let id = response.id;
-            console.log('document id', response.id);
-            this._domNodes.set(id, this.domDocument);
+            this._domNodes.set(response.id, this.documentInfo.domDocument);
           }.bind(this));
         } else {
           this.client = null;
@@ -247,7 +210,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       executeCommand(command) {
         this._domCommandApplier.apply(command);
         this._parsedCommandApplier.apply(command);
-        this.textContent = dom5.serialize(this.astDocument);
+        this.set('documentInfo.textContent',
+            dom5.serialize(this.documentInfo.astDocument));
         this.client.sendCommand(command).then(function(response) {
           this.fire('designer-document-update', response);
         }.bind(this));
@@ -305,7 +269,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let node;
       let nextId = 1;
       while(node = iterator.nextNode()) {
-        node.setAttribute(nodeIdProperty, nextId++);
+        node.setAttribute(sourceIdAttribute, nextId++);
       }
 
       doc.head.insertBefore(createFrameScriptElement(frameScript, doc),

--- a/elements/designer-frame/designer-frame.html
+++ b/elements/designer-frame/designer-frame.html
@@ -48,9 +48,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       properties: {
 
-        document: {
+        documentInfo: {
           type: Object,
-          observer: '_documentChanged',
+          observer: '_documentInfoChanged',
         },
 
         clientConnection: {
@@ -60,16 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       },
 
-      /**
-       * @returns {Promise} a Promise that completes when the document has
-       * loaded.
-       *
-       * Note: this method isn't called from anywhere than can handle the
-       * Promise at the moment. The assumption for now is that the side-effect
-       * here (setting this.client) is only needed after the content loads
-       * anyway, such as when the use clicks on an element.
-       */
-      _documentChanged() {
+      _documentInfoChanged() {
         if (this.clientConnection != null) {
           this.clientConnection.disconnect();
           this.clientConnection = null;
@@ -88,7 +79,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               new ClientConnection(window, this._frame.contentWindow);
         }.bind(this));
 
-        this._frame.src = getDocumentUrl(this.document);;
+        this._frame.src = getDocumentUrl(this.documentInfo.domDocument);
       },
 
     });

--- a/elements/designer-inspector/designer-inspector.html
+++ b/elements/designer-inspector/designer-inspector.html
@@ -23,25 +23,21 @@ Inspects an element and provides tidbits about its properties, styles, and more.
       display: block;
       overflow: auto;
     }
-    .dumped-state {
-      font-size: 0.7em;
-      overflow: hidden;
-    }
   </style>
 
   <template>
     <designer-style-inspector
-        source-document="{{sourceDocument}}"
-        element-info="{{elementInfo}}"></designer-style-inspector>
+        source-document="[[sourceDocument]]"
+        selection="[[selection]]">
+    </designer-style-inspector>
     <designer-property-inspector
-        element-info="{{elementInfo}}"></designer-property-inspector>
-<!--         <div>{{_dumpedState}}</div> -->
+        selection="[[selection]]">
+    </designer-property-inspector>
   </template>
 
 </dom-module>
 
 <script>
-
   Polymer({
 
     is: 'designer-inspector',
@@ -51,20 +47,11 @@ Inspects an element and provides tidbits about its properties, styles, and more.
       /**
        * Metadata published by the stage about the currently selected element.
        */
-      'elementInfo': {
-        type:      Object,
-        observer: '_elementInfoChanged',
-      },
+      selection: Object,
 
       /** The document where edits should be made */
-      'sourceDocument': Object,
-
-    },
-
-    _elementInfoChanged() {
-      this._dumpedState = JSON.stringify(this.elementInfo, null, 1);
+      documentInfo: Object,
     },
 
   });
-
 </script>

--- a/elements/designer-inspector/designer-property-inspector.html
+++ b/elements/designer-inspector/designer-property-inspector.html
@@ -52,9 +52,9 @@ Polymer({
     /**
      * Metadata published by the stage about the currently selected element.
      */
-    elementInfo: {
-      type:      Object,
-      observer: '_elementInfoChanged',
+    selection: {
+      type: Object,
+      observer: '_selectionChanged',
     },
 
   },
@@ -63,10 +63,10 @@ Polymer({
     this._hide = true;
   },
 
-  _elementInfoChanged() {
-    this._properties = (this.elementInfo &&
-                         this.elementInfo.analyzed &&
-                         this.elementInfo.analyzed.properties) || [];
+  _selectionChanged() {
+    this._properties = (this.selection &&
+        this.selection.analysisInfo &&
+        this.selection.analysisInfo.properties) || [];
     if (this._properties.length == 0) {
       this._hide = true;
     } else {

--- a/elements/designer-inspector/designer-style-inspector.html
+++ b/elements/designer-inspector/designer-style-inspector.html
@@ -65,13 +65,13 @@ define([
       /**
        * Metadata published by the stage about the currently selected element.
        */
-      elementInfo: {
-        type:      Object,
-        observer: '_elementInfoChanged',
+      selection: {
+        type: Object,
+        observer: '_selectionChanged',
       },
 
       /** The document where edits should be made */
-      sourceDocument: Object,
+      documentInfo: Object,
 
     },
 
@@ -79,8 +79,10 @@ define([
       'designer-element-style-changed': '_styleChanged',
     },
 
-    _elementInfoChanged() {
-      this._sheets = (this.elementInfo && this.elementInfo.styles) || [];
+    _selectionChanged() {
+      this._sheets = (this.selection &&
+          this.selection.elementInfo &&
+          this.selection.elementInfo.styles) || [];
     },
 
     _styleChanged(event, info) {
@@ -90,10 +92,11 @@ define([
     },
 
     _updateSheet(sheet, rule, key, value) {
-      console.assert(this.sourceDocument);
+      console.assert(this.documentInfo);
       console.assert(key);
       let sheetSourceId = sheet.ownerSourceId;
-      let sourceStyle = this.sourceDocument.querySelector(`[__designer_node_id__="${sheetSourceId}"]`);
+      let sourceStyle = this.documentInfo.domDocument
+          .querySelector(`[${domUtils.sourceIdAttribute}="${sheetSourceId}"]`);
       let sheetSource = sourceStyle.textContent;
       let parsedSheet = rework.parse(sheetSource);
 
@@ -102,9 +105,11 @@ define([
       console.assert(parsedRule, 'Expected to find a parsed rule matching', rule);
       // TODO(nevir): We are going to have to support multiple transformations
       // (addition, deletion).
-      let newSource = reworkUtils.replaceProperty(sheetSource, parsedRule, key, value);
+      let newSource =
+          reworkUtils.replaceProperty(sheetSource, parsedRule, key, value);
 
-      this.fire('designer-command', commands.setTextContent(sheetSourceId, sheetSource, newSource));
+      this.fire('designer-command',
+          commands.setTextContent(sheetSourceId, sheetSource, newSource));
     },
 
   });

--- a/elements/designer-stage/designer-stage.html
+++ b/elements/designer-stage/designer-stage.html
@@ -122,33 +122,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     'use strict';
 
     /**
-     * `<designer-stage>` is a WYSIWYG editing surface and container for
-     * an HTML document.
-     *
-     * @typedef {{
-     *   path: string,
-     *   tagName: string,
-     *   display: string,
-     *   position: string,
-     * }} CurrentElementInfo
+     * `<designer-stage>` hanldes user input for WYSIWYG editing.
      */
     Polymer({
       is: 'designer-stage',
 
       properties: {
 
-        /**
-         * @type {CurrentElementInfo}
-         */
-        currentElementInfo: {
+        selection: {
           type: Object,
-          notify: true,
-          value: null,
-        },
-
-        currentSourceId: {
-          type: String,
-          notify: true,
+          observer: '_selectionChanged',
         },
 
         /**
@@ -182,16 +165,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           value: false,
         },
 
-        domDocument: {
+        documentInfo: {
           type: Object,
-          observer: '_domDocumentChanged',
+          observer: '_documentInfoChanged',
         },
 
         client: {
-          type: Object,
-        },
-
-        analyzer: {
           type: Object,
         },
 
@@ -212,12 +191,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._reset();
       },
 
-      _domDocumentChanged() {
+      _documentInfoChanged() {
         this._reset();
       },
 
       _reset() {
-        this.currentElementInfo = null;
         this.currentMousePosition = null;
         this.insertPosition = null;
         this.hoverSourceId = null;
@@ -228,17 +206,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.$.caret.style.display = 'none';
       },
 
-      applyDocumentUpdate(update) {
-        this._updateCurrentElement(update.elementInfo);
-        this._updateSelectionBounds(update.bounds);
-      },
-
-      getAnalyzedElement(elementInfo) {
-        return this.analyzer.elementsByTagName[elementInfo.tagName.toLowerCase()];
-      },
-
       _updateSelectionBounds(bounds) {
-        this.currentElementInfo.bounds = bounds;
         var style = this.$.selection.style;
         style.display = 'block';
         style.top = bounds.top + 'px';
@@ -247,31 +215,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         style.height = bounds.height + 'px';
       },
 
-      _updateCurrentElement(elementInfo) {
-        // TODO(justinfagnani): the stage should not be invoking the analyzer.
-        // move this to designer-document
-        elementInfo.analyzed = this.getAnalyzedElement(elementInfo);
-        this.currentElementInfo = elementInfo;
+      _selectElement(elementInfo) {
         this.fire('designer-select-element', {
+          // TODO(justinfagnani): this is a waste of the elementInfo, which
+          // will be retreived again by designer-document, but it's a little
+          // simpler to reason about elementInfo always coming from one place
+          // at the moment.
           sourceId: elementInfo.sourceId,
         }, { bubbles: true, });
+      },
 
-        // Set the valid resize handles
-        var position = elementInfo.position;
-        var display = elementInfo.display;
+      _selectionChanged() {
+        if (this.selection == null) {
+          this._reset();
+          return;
+        }
+        if (this.selection.bounds) {
+          this._updateSelectionBounds(this.selection.bounds);
+          // Set the valid resize handles
+          var position = this.selection.elementInfo.position;
+          var display = this.selection.elementInfo.display;
 
-        if (position === 'static' || position === 'relative') {
-          if (display === 'block') {
-            selection.directions = ResizeDirection.WIDTH_HEIGHT;
-          } else if (display === 'inline') {
-            selection.directions = [];
+          if (position === 'static' || position === 'relative') {
+            if (display === 'block') {
+              this.$.selection.directions = ResizeDirection.WIDTH_HEIGHT;
+            } else if (display === 'inline') {
+              this.$.selection.directions = [];
+            }
+            this.$.proxy.innerHTML = this.selection.elementInfo.proxy;
+          } else if (position === 'absolute') {
+            this.$.selection.directions = ResizeDirection.ALL_DIRECTIONS;
+          } else {
+            console.warn("can't handle position", data.position);
+            this.$.selection.directions = [];
           }
-          this.$.proxy.innerHTML = this.currentElementInfo.proxy;
-        } else if (position === 'absolute') {
-          selection.directions = ResizeDirection.ALL_DIRECTIONS;
         } else {
-          console.warn("can't handle position", data.position);
-          selection.directions = [];
+          this.$.selection.hide();
         }
 
       },
@@ -294,8 +273,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         hoverStyle.width = bounds.width + 'px';
         hoverStyle.height = bounds.height + 'px';
 
-        if (this.currentElementInfo &&
-            this.currentElementInfo.position == 'static') {
+        if (this.selection &&
+            this.selection.elementInfo.position == 'static') {
           var verticalMid = bounds.top + bounds.height / 2;
           var insertAbove = this.currentMousePosition.y < verticalMid;
           var insertBelow = this.currentMousePosition.y > verticalMid;
@@ -329,7 +308,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._mode = 'text';
         this.$.selection.hide();
         let style = this.$['text-edit-selection'].style;
-        let bounds = this.currentElementInfo.bounds;
+        let bounds = this.selection.bounds;
         style.display = 'block';
         // offset must be keep in sync with the border size in CSS
         style.top = (bounds.top - 4) + 'px';
@@ -351,6 +330,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var bounds = e.detail.bounds;
         this.client.selectionBoundsChanged(bounds)
           .then(function(response) {
+            // TODO(justinfagnani): fire event
             this._updateSelectionBounds(response.bounds);
           }.bind(this));
       },
@@ -372,7 +352,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 }.bind(this));
               };
               if (response.elementInfo) {
-                this._updateCurrentElement(response.elementInfo);
+                this._selectElement(response.elementInfo);
               }
               if (response.bounds) {
                 this._updateSelectionBounds(response.bounds);
@@ -384,7 +364,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _updateDragProxy(bounds) {
         var proxy = this.$.proxy;
         var proxyStyle = proxy.style;
-        if (this.currentElementInfo.position === 'static') {
+        if (this.selection.elementInfo.position === 'static') {
           proxyStyle.display = 'block';
           proxyStyle.top = bounds.top + 'px';
           proxyStyle.left = bounds.left + 'px';
@@ -406,8 +386,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         let position = domUtils.toLocalPosition(this, e.clientX, e.clientY);
         this.client.selectElementAtPoint(position.x, position.y)
             .then(function(response) {
-              this._updateCurrentElement(response.elementInfo);
-              this._updateSelectionBounds(response.bounds);
+              this._selectElement(response.elementInfo);
               // Start a drag after selection if the mouse is still down.
               if (this._mouseDown) {
                 this.$.selection._boundsDown(e);
@@ -436,7 +415,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (this.hoverSourceId != null && this.insertPosition != null) {
           this.fire('designer-command',
             commands.moveElement(
-              this.currentElementInfo.sourceId,
+              this.selection.elementInfo.sourceId,
               this.hoverSourceId,
               this.insertPosition));
         }
@@ -449,8 +428,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         let position = domUtils.toLocalPosition(this, e.clientX, e.clientY);
         this.client.selectElementAtPoint(position.x, position.y)
           .then(function(response) {
-            this._updateCurrentElement(response.elementInfo);
-            this._updateSelectionBounds(response.bounds);
+            this._selectElement(response.elementInfo);
             this.enterTextMode();
           }.bind(this));
       },
@@ -459,8 +437,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         let position = domUtils.toLocalPosition(this, e.clientX, e.clientY);
         this.client.selectElementAtPoint(position.x, position.y)
           .then(function(response) {
-            this._updateCurrentElement(response.elementInfo);
-            this._updateSelectionBounds(response.bounds);
+            this._selectElement(response.elementInfo);
           }.bind(this));
       },
 

--- a/src/protocol/DocumentClient.js
+++ b/src/protocol/DocumentClient.js
@@ -80,12 +80,31 @@ define('polymer-designer/protocol/DocumentClient', function() {
     }
 
     /**
+     * Selects an element by its elementInfo.id.
+     *
      * @returns {Promise}
      */
-    selectElementAtPath(path) {
+    selectElement(id) {
       return this.connection.request({
-        messageType: 'selectElementAtPath',
-        path: path,
+        messageType: 'selectElement',
+        id: id,
+      });
+    }
+
+    /**
+     * Selects an element by its sourceId.
+     *
+     * In live documents where there is more than one element with the same
+     * sourceId (as with an expanded template/repeat), we'll need a way to
+     * determine the "original" element.
+     *
+     * @returns {Promise}
+     */
+    selectElementForSourceId(sourceId) {
+      console.assert(sourceId != null);
+      return this.connection.request({
+        messageType: 'selectElementForSourceId',
+        sourceId: sourceId,
       });
     }
 


### PR DESCRIPTION
This PR places selection related things in the `selection` property of `designer-document`, and the document related things in `documentInfo`. It does not reorganize the bundles yet.

It also changes how elementInfo is retrieved. It used to be that designer-stage could set the elementInfo, since it would receive one as a part of its selection operations. Not designer-stage just fires an event that sets the current sourceId, and `designer-document` retrieves the elementInfo for that ID. This is a little less efficient, but easier to reason about and handle in the context of the changes. Most importantly with only one producer of elementInfo in the app, it's cleary the component that needs to connect up the analyzer information. In the near future we can revisit whether there are multiple sources of elementInfo and how to retrieve all related info either eagerly or on-demand.

There are a few commits in this PR that I'll squash. Let me know if it's helpful to reorganize them to review individually.