### PR TITLE
Remove extraneous semicolon

### DIFF
--- a/tools/frame-script.js
+++ b/tools/frame-script.js
@@ -29,9 +29,7 @@ var postamble = 'define(["polymer-designer/protocol/ServerConnection", ' +
     '})();';
 
 function buildFrameScript(files) {
-
   return  preamble + files.join('\n') + postamble;
-    ;
 }
 
 module.exports = {


### PR DESCRIPTION
Remove an extraneous semicolon on a line of its own, which is technically an unreachable statement. Trivial I know but still probably worth removing.