### PR TITLE
Remove duplicate object property

### DIFF
--- a/src/dom-utils/dom-utils.js
+++ b/src/dom-utils/dom-utils.js
@@ -186,7 +186,6 @@ define('polymer-designer/dom-utils', () => {
     getSourceId: getSourceId,
     hide: hide,
     isDescendant: isDescendant,
-    isDescendant: isDescendant,
     parseQueryString: parseQueryString,
     renameNode: renameNode,
     setBounds: setBounds,


### PR DESCRIPTION
Remove an duplicate property on an object. Entirely behaviour preserving as the values were the same.

This was also found using [lgtm.com](https://lgtm.com/projects/g/Polymer/designer/alerts/), where it was flagged as a duplicate property. Harmless on this occasion but can sometimes be a really subtle and hard to find bug.