### PR TITLE
Fix parse5.html error.

### DIFF
--- a/elements/designer-breadcrumb/designer-breadcrumb.html
+++ b/elements/designer-breadcrumb/designer-breadcrumb.html
@@ -41,7 +41,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-define(['polymer-designer/dom-utils'], (domUtils) => {
+define(['polymer-designer/dom-utils', 'dom5'], (domUtils, dom5) => {
   'use strict';
 
   Polymer({
@@ -127,7 +127,7 @@ define(['polymer-designer/dom-utils'], (domUtils) => {
           this._selectedIndex < this._nodePath.length) {
         let newNode = this._nodePath[this._selectedIndex];
         this.fire('designer-select-element', {
-          sourceId: domUtils.getSourceId(newNode),
+          sourceId: dom5.getAttribute(newNode, domUtils.sourceIdAttribute),
         }, { bubbles: true, });
       }
     },

--- a/elements/designer-document/designer-document.html
+++ b/elements/designer-document/designer-document.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../src/protocol/document-client.html">
 <link rel="import" href="../../src/rework-utils/rework-utils.html">
 <link rel="import" href="../../src/uri/uri.html">
-<link rel="import" href="../../vendor/parse5.html">
+<link rel="import" href="../../src/parse5/parse5.html">
 
 <dom-module id="designer-document">
 

--- a/src/parse5/parse5.html
+++ b/src/parse5/parse5.html
@@ -1,0 +1,10 @@
+<!--
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<script src="../../vendor/parse5.js" as="parse5"></script>

--- a/test/path/path_test.html
+++ b/test/path/path_test.html
@@ -19,7 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="../../../polymer/polymer.html"/>
     <link rel="import" href="../../src/path/path.html"/>
     <link rel="import" href="../../src/dom5/dom5.html"/>
-    <link rel="import" href="../../vendor/parse5.html">
+    <link rel="import" href="../../src/parse5/parse5.html">
   </head>
   <body>
     <div id="mocha"></div>


### PR DESCRIPTION
PR is trying to fix the parse5.html error by adding a new parse5.html under src/parse5 (followed the same pattern as dom5).
Also fixes  an "element.getAttribute is not a function" error when selecting a tag on document breadcrumb.